### PR TITLE
Update dependencies

### DIFF
--- a/FunctionApp/pom.xml
+++ b/FunctionApp/pom.xml
@@ -26,7 +26,7 @@
         <dependency>
             <groupId>com.microsoft.graph</groupId>
             <artifactId>microsoft-graph</artifactId>
-            <version>5.75.0</version>
+            <version>5.76.0</version>
         </dependency>
         <dependency>
             <groupId>com.azure</groupId>
@@ -37,22 +37,22 @@
         <dependency>
             <groupId>com.github.librepdf</groupId>
             <artifactId>openpdf</artifactId>
-            <version>1.3.32</version>
+            <version>1.3.33</version>
         </dependency>
         <dependency>
             <groupId>org.bouncycastle</groupId>
             <artifactId>bcutil-jdk18on</artifactId>
-            <version>1.76</version>
+            <version>1.77</version>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.15.3</version>
+            <version>2.16.0</version>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.dataformat</groupId>
             <artifactId>jackson-dataformat-xml</artifactId>
-            <version>2.15.3</version>
+            <version>2.16.0</version>
         </dependency>
 
 
@@ -73,7 +73,7 @@
         <dependency>
             <groupId>org.jetbrains</groupId>
             <artifactId>annotations</artifactId>
-            <version>24.0.1</version>
+            <version>24.1.0</version>
             <scope>compile</scope>
         </dependency>
     </dependencies>


### PR DESCRIPTION
This pull request updates the following dependencies:

[INFO]   com.fasterxml.jackson.core:jackson-databind ......... 2.15.3 -> 2.16.0
[INFO]                                                         2.15.3 -> 2.16.0
[INFO]   com.github.librepdf:openpdf ......................... 1.3.32 -> 1.3.33
[INFO]   com.microsoft.graph:microsoft-graph ................. 5.75.0 -> 5.76.0
[INFO]   org.bouncycastle:bcutil-jdk18on ......................... 1.76 -> 1.77
[INFO]   org.jetbrains:annotations ........................... 24.0.1 -> 24.1.0