### PR TITLE
Fix build job condition

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -20,7 +20,7 @@ jobs:
 
   build:
     needs: changes
-    if: ${{ needs.changes.outputs.function-app == 'true' }}
+    if: ${{ needs.changes.outputs.function-app == true }}
     uses: ./.github/workflows/maven.yml
 
   analyze:


### PR DESCRIPTION
The CodeQL workflow has not been running properly, possibly because of me comparing a boolean true to a string true. This fixes the erroneous string true.