### PR TITLE
Update dependencies

### DIFF
--- a/FunctionApp/pom.xml
+++ b/FunctionApp/pom.xml
@@ -26,12 +26,12 @@
         <dependency>
             <groupId>com.microsoft.graph</groupId>
             <artifactId>microsoft-graph</artifactId>
-            <version>6.24.0</version>
+            <version>6.30.1</version>
         </dependency>
         <dependency>
             <groupId>com.azure</groupId>
             <artifactId>azure-identity</artifactId>
-            <version>1.14.2</version>
+            <version>1.15.3</version>
         </dependency>
 
         <dependency>
@@ -42,17 +42,17 @@
         <dependency>
             <groupId>org.bouncycastle</groupId>
             <artifactId>bcutil-jdk18on</artifactId>
-            <version>1.79</version>
+            <version>1.80</version>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.18.2</version>
+            <version>2.18.3</version>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.dataformat</groupId>
             <artifactId>jackson-dataformat-xml</artifactId>
-            <version>2.18.2</version>
+            <version>2.18.3</version>
         </dependency>
 
 
@@ -60,20 +60,20 @@
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter</artifactId>
-            <version>5.11.4</version>
+            <version>5.12.0</version>
             <scope>test</scope>
         </dependency>
 
         <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
-            <version>5.14.2</version>
+            <version>5.15.2</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.jetbrains</groupId>
             <artifactId>annotations</artifactId>
-            <version>26.0.1</version>
+            <version>26.0.2</version>
             <scope>compile</scope>
         </dependency>
     </dependencies>


### PR DESCRIPTION
This pull request updates the following dependencies:

[INFO]   com.azure:azure-identity ............................ 1.14.2 -> 1.15.3
[INFO]   com.fasterxml.jackson.core:jackson-databind ......... 2.18.2 -> 2.18.3
[INFO]                                                         2.18.2 -> 2.18.3
[INFO]   com.microsoft.graph:microsoft-graph ................. 6.24.0 -> 6.30.1
[INFO]   org.bouncycastle:bcutil-jdk18on ......................... 1.79 -> 1.80
[INFO]   org.jetbrains:annotations ........................... 26.0.1 -> 26.0.2
[INFO]   org.junit.jupiter:junit-jupiter ..................... 5.11.4 -> 5.12.0
[INFO]   org.mockito:mockito-core ............................ 5.14.2 -> 5.15.2