### PR TITLE
Update dependencies

### DIFF
--- a/FunctionApp/pom.xml
+++ b/FunctionApp/pom.xml
@@ -26,18 +26,18 @@
         <dependency>
             <groupId>com.microsoft.graph</groupId>
             <artifactId>microsoft-graph</artifactId>
-            <version>6.30.1</version>
+            <version>6.39.0</version>
         </dependency>
         <dependency>
             <groupId>com.azure</groupId>
             <artifactId>azure-identity</artifactId>
-            <version>1.15.3</version>
+            <version>1.16.1</version>
         </dependency>
 
         <dependency>
             <groupId>com.github.librepdf</groupId>
             <artifactId>openpdf</artifactId>
-            <version>2.0.3</version>
+            <version>2.0.5</version>
         </dependency>
         <dependency>
             <groupId>org.bouncycastle</groupId>
@@ -47,12 +47,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.18.3</version>
+            <version>2.19.0</version>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.dataformat</groupId>
             <artifactId>jackson-dataformat-xml</artifactId>
-            <version>2.18.3</version>
+            <version>2.19.0</version>
         </dependency>
 
 
@@ -60,14 +60,14 @@
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter</artifactId>
-            <version>5.12.0</version>
+            <version>5.13.0</version>
             <scope>test</scope>
         </dependency>
 
         <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
-            <version>5.15.2</version>
+            <version>5.18.0</version>
             <scope>test</scope>
         </dependency>
         <dependency>


### PR DESCRIPTION
This pull request updates the following dependencies:

[INFO]   com.azure:azure-identity ............................ 1.15.3 -> 1.16.1
[INFO]   com.fasterxml.jackson.core:jackson-databind ......... 2.18.3 -> 2.19.0
[INFO]                                                         2.18.3 -> 2.19.0
[INFO]   com.github.librepdf:openpdf ........................... 2.0.3 -> 2.0.5
[INFO]                                                     3.1.0 -> 3.1.1-alpha
[INFO]   com.microsoft.graph:microsoft-graph ................. 6.30.1 -> 6.39.0
[INFO]   org.junit.jupiter:junit-jupiter ..................... 5.12.0 -> 5.13.0
[INFO]   org.mockito:mockito-core ............................ 5.15.2 -> 5.18.0