### PR TITLE
Update dependencies

### DIFF
--- a/FunctionApp/pom.xml
+++ b/FunctionApp/pom.xml
@@ -26,33 +26,33 @@
         <dependency>
             <groupId>com.microsoft.graph</groupId>
             <artifactId>microsoft-graph</artifactId>
-            <version>6.30.1</version>
+            <version>6.48.0</version>
         </dependency>
         <dependency>
             <groupId>com.azure</groupId>
             <artifactId>azure-identity</artifactId>
-            <version>1.15.3</version>
+            <version>1.17.0-beta.1</version>
         </dependency>
 
         <dependency>
             <groupId>com.github.librepdf</groupId>
             <artifactId>openpdf</artifactId>
-            <version>2.0.3</version>
+            <version>2.2.4</version>
         </dependency>
         <dependency>
             <groupId>org.bouncycastle</groupId>
             <artifactId>bcutil-jdk18on</artifactId>
-            <version>1.80</version>
+            <version>1.81</version>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.18.3</version>
+            <version>2.19.2</version>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.dataformat</groupId>
             <artifactId>jackson-dataformat-xml</artifactId>
-            <version>2.18.3</version>
+            <version>2.19.2</version>
         </dependency>
 
 
@@ -60,14 +60,14 @@
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter</artifactId>
-            <version>5.12.0</version>
+            <version>6.0.0-M2</version>
             <scope>test</scope>
         </dependency>
 
         <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
-            <version>5.15.2</version>
+            <version>5.18.0</version>
             <scope>test</scope>
         </dependency>
         <dependency>


### PR DESCRIPTION
This pull request updates the following dependencies:

[INFO]   com.azure:azure-identity ..................... 1.15.3 -> 1.17.0-beta.1
[INFO]   com.fasterxml.jackson.core:jackson-databind ......... 2.18.3 -> 2.19.2
[INFO]                                                         2.18.3 -> 2.19.2
[INFO]   com.github.librepdf:openpdf ........................... 2.0.3 -> 2.2.4
[INFO]                                                     3.1.0 -> 3.1.1-alpha
[INFO]   com.microsoft.graph:microsoft-graph ................. 6.30.1 -> 6.48.0
[INFO]   org.bouncycastle:bcutil-jdk18on ......................... 1.80 -> 1.81
[INFO]   org.junit.jupiter:junit-jupiter ................... 5.12.0 -> 6.0.0-M2
[INFO]   org.mockito:mockito-core ............................ 5.15.2 -> 5.18.0