### PR TITLE
Update dependencies

### DIFF
--- a/FunctionApp/pom.xml
+++ b/FunctionApp/pom.xml
@@ -26,33 +26,33 @@
         <dependency>
             <groupId>com.microsoft.graph</groupId>
             <artifactId>microsoft-graph</artifactId>
-            <version>6.39.0</version>
+            <version>6.59.0</version>
         </dependency>
         <dependency>
             <groupId>com.azure</groupId>
             <artifactId>azure-identity</artifactId>
-            <version>1.16.1</version>
+            <version>1.18.1</version>
         </dependency>
 
         <dependency>
             <groupId>com.github.librepdf</groupId>
             <artifactId>openpdf</artifactId>
-            <version>2.0.5</version>
+            <version>3.0.0</version>
         </dependency>
         <dependency>
             <groupId>org.bouncycastle</groupId>
             <artifactId>bcutil-jdk18on</artifactId>
-            <version>1.80</version>
+            <version>1.83</version>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.19.0</version>
+            <version>2.20.1</version>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.dataformat</groupId>
             <artifactId>jackson-dataformat-xml</artifactId>
-            <version>2.19.0</version>
+            <version>2.20.1</version>
         </dependency>
 
 
@@ -60,20 +60,20 @@
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter</artifactId>
-            <version>5.13.0</version>
+            <version>6.0.1</version>
             <scope>test</scope>
         </dependency>
 
         <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
-            <version>5.18.0</version>
+            <version>5.21.0</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.jetbrains</groupId>
             <artifactId>annotations</artifactId>
-            <version>26.0.2</version>
+            <version>26.0.2-1</version>
             <scope>compile</scope>
         </dependency>
     </dependencies>


### PR DESCRIPTION
This pull request updates the following dependencies:

[INFO]   com.azure:azure-identity ..................... 1.16.1 -> 1.19.0-beta.1
[INFO]   com.fasterxml.jackson.core:jackson-databind ......... 2.19.0 -> 2.20.1
[INFO]                                                         2.19.0 -> 2.20.1
[INFO]   com.github.librepdf:openpdf ........................... 2.0.5 -> 3.0.0
[INFO]                                                           3.1.0 -> 3.2.2
[INFO]   com.microsoft.graph:microsoft-graph ................. 6.39.0 -> 6.59.0
[INFO]   org.bouncycastle:bcutil-jdk18on ......................... 1.80 -> 1.83
[INFO]   org.jetbrains:annotations ......................... 26.0.2 -> 26.0.2-1
[INFO]   org.junit.jupiter:junit-jupiter ................... 5.13.0 -> 6.1.0-M1
[INFO]   org.mockito:mockito-core ............................ 5.18.0 -> 5.21.0