### PR TITLE
Refactor fill endpoint input/output and enforce strict compiler warnings

### DIFF
--- a/FunctionApp/pom.xml
+++ b/FunctionApp/pom.xml
@@ -86,6 +86,12 @@
                 <configuration>
                     <release>21</release>
                     <encoding>${project.build.sourceEncoding}</encoding>
+                    <showWarnings>true</showWarnings>
+                    <showDeprecation>true</showDeprecation>
+                    <failOnWarning>true</failOnWarning>
+                    <compilerArgs>
+                        <arg>-Xlint:all</arg>
+                    </compilerArgs>
                 </configuration>
             </plugin>
             <plugin>

--- a/FunctionApp/src/main/java/app/djk/RestPdfFormFiller/Pdf/RestPdfApi.java
+++ b/FunctionApp/src/main/java/app/djk/RestPdfFormFiller/Pdf/RestPdfApi.java
@@ -84,21 +84,23 @@ public class RestPdfApi {
         return isXfaForm(new ByteArrayInputStream(pdfBytes));
     }
 
-    //TODO Given JSON content for specified form, get PDF with form fields filled with content
+
     public static byte[] fillXfaForm(final InputStream pdfStream, final String jsonFormData) throws IOException, ParserConfigurationException, SAXException {
-        final var pdfBytes = pdfStream.readAllBytes();
+        return fillXfaForm(pdfStream.readAllBytes(), jsonFormData);
+    }
+
+    public static byte[] fillXfaForm(final byte[] pdfBytes, final String jsonFormData) throws IOException, ParserConfigurationException, SAXException {
         if (!isXfaForm(pdfBytes)) throw new InvalidXfaFormException();
 
-        final var outputStream = new ByteArrayOutputStream();
-        final var pdfStamper = new PdfStamper(new PdfReader(pdfBytes), outputStream);
+        try (final var outputStream = new ByteArrayOutputStream();
+             final var pdfStamper = new PdfStamper(new PdfReader(pdfBytes), outputStream)) {
+            final var xmlData = DataFormatter.convertJsonToXml(jsonFormData);
 
-        final var xmlData = DataFormatter.convertJsonToXml(jsonFormData);
+            final var xfaForm = new XfaForm(pdfStamper.getReader());
+            xfaForm.fillXfaForm(xmlData);
+            xfaForm.setChanged(true);
 
-        final var xfaForm = new XfaForm(pdfStamper.getReader());
-        xfaForm.fillXfaForm(xmlData);
-        xfaForm.setChanged(true);
-
-        pdfStamper.close();
-        return outputStream.toByteArray();
+            return outputStream.toByteArray();
+        }
     }
 }

--- a/FunctionApp/src/main/java/app/djk/RestPdfFormFiller/Pdf/RestPdfApi.java
+++ b/FunctionApp/src/main/java/app/djk/RestPdfFormFiller/Pdf/RestPdfApi.java
@@ -11,7 +11,11 @@ import javax.xml.transform.OutputKeys;
 import javax.xml.transform.TransformerException;
 import javax.xml.transform.dom.DOMSource;
 import javax.xml.transform.stream.StreamResult;
-import java.io.*;
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.StringWriter;
 import java.util.List;
 
 public class RestPdfApi {
@@ -81,10 +85,12 @@ public class RestPdfApi {
     }
 
     //TODO Given JSON content for specified form, get PDF with form fields filled with content
-    public static OutputStream fillXfaForm(final InputStream pdfStream, final String jsonFormData) throws IOException, ParserConfigurationException, SAXException {
-        if (!isXfaForm(pdfStream)) throw new InvalidXfaFormException();
-        var outFile = new BufferedOutputStream(new ByteArrayOutputStream());
-        var pdfStamper = new PdfStamper(new PdfReader(pdfStream), outFile);
+    public static byte[] fillXfaForm(final InputStream pdfStream, final String jsonFormData) throws IOException, ParserConfigurationException, SAXException {
+        final var pdfBytes = pdfStream.readAllBytes();
+        if (!isXfaForm(pdfBytes)) throw new InvalidXfaFormException();
+
+        final var outputStream = new ByteArrayOutputStream();
+        final var pdfStamper = new PdfStamper(new PdfReader(pdfBytes), outputStream);
 
         final var xmlData = DataFormatter.convertJsonToXml(jsonFormData);
 
@@ -93,7 +99,6 @@ public class RestPdfApi {
         xfaForm.setChanged(true);
 
         pdfStamper.close();
-        outFile.flush();
-        return outFile;
+        return outputStream.toByteArray();
     }
 }

--- a/FunctionApp/src/main/java/app/djk/RestPdfFormFiller/functions/HttpTriggerFunctions.java
+++ b/FunctionApp/src/main/java/app/djk/RestPdfFormFiller/functions/HttpTriggerFunctions.java
@@ -17,7 +17,10 @@ import com.microsoft.kiota.ApiException;
 import okhttp3.FormBody;
 import okhttp3.OkHttpClient;
 import okhttp3.Request;
+import tools.jackson.databind.ObjectMapper;
+import tools.jackson.databind.node.JsonNodeType;
 
+import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.*;
@@ -27,6 +30,8 @@ import java.util.logging.Level;
  * Azure Functions with HTTP Trigger.
  */
 public class HttpTriggerFunctions {
+    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+
     /**
      * Azure Function that receives a Base64-encoded PDF file and returns the XFA form field data.
      * This function takes an HTTP POST request. It requires a query parameter of <code>format</code>
@@ -108,21 +113,17 @@ public class HttpTriggerFunctions {
             final ExecutionContext context) {
 
 
-        // get PDF from SPO
-        // get form content from request body
-        // fill form with content
-        // return PDF in response body (don't edit file)
-
         return errorHandler(request, context, () -> {
-
-            final var fileStream = getFileInputStreamFromSpo(request);
             final var requestBody = request.getBody().orElseThrow(EmptyRequestBodyException::new);
+            final var fillRequest = parseFillRequest(requestBody);
 
-            final var filledFormStream = RestPdfApi.fillXfaForm(fileStream, requestBody);
-            final var base64EncodedForm = Base64.getEncoder().encode(filledFormStream.toString().getBytes());
+            final var templateBytes = Base64.getDecoder().decode(fillRequest.templateBase64());
+            final var templateStream = new ByteArrayInputStream(templateBytes);
+
+            final var filledPdfBytes = RestPdfApi.fillXfaForm(templateStream, fillRequest.formDataJson());
+            final var base64EncodedForm = Base64.getEncoder().encodeToString(filledPdfBytes);
 
             return request.createResponseBuilder(HttpStatus.OK).body(base64EncodedForm).build();
-            //return request.createResponseBuilder(HttpStatus.NOT_IMPLEMENTED).build();
         });
     }
 
@@ -217,6 +218,39 @@ public class HttpTriggerFunctions {
     @FunctionalInterface
     private interface ThrowingSupplier<T> {
         T get() throws Exception;
+    }
+
+    private static FillRequest parseFillRequest(final String requestBody) {
+        try {
+            final var rootNode = OBJECT_MAPPER.readTree(requestBody);
+
+            final var templateNode = rootNode.path("templateBase64");
+            final var templateBase64 = templateNode.stringValue();
+            if (templateNode.getNodeType() != JsonNodeType.STRING || templateBase64 == null || templateBase64.isBlank()) {
+                throw new IllegalArgumentException("Request field 'templateBase64' must be a non-empty string.");
+            }
+
+            final var formDataNode = rootNode.path("formData");
+            if (!formDataNode.isObject()) {
+                throw new IllegalArgumentException("Request field 'formData' must be a JSON object.");
+            }
+
+            final String formDataJson;
+            if (formDataNode.has("data") && formDataNode.size() == 1 && formDataNode.path("data").isObject()) {
+                formDataJson = formDataNode.toString();
+            } else {
+                final var normalizedRoot = OBJECT_MAPPER.createObjectNode();
+                normalizedRoot.set("data", formDataNode);
+                formDataJson = normalizedRoot.toString();
+            }
+
+            return new FillRequest(templateBase64, formDataJson);
+        } catch (RuntimeException e) {
+            throw new IllegalArgumentException("Request body must be valid JSON.", e);
+        }
+    }
+
+    private record FillRequest(String templateBase64, String formDataJson) {
     }
 
     /**

--- a/FunctionApp/src/main/java/app/djk/RestPdfFormFiller/functions/HttpTriggerFunctions.java
+++ b/FunctionApp/src/main/java/app/djk/RestPdfFormFiller/functions/HttpTriggerFunctions.java
@@ -17,6 +17,7 @@ import com.microsoft.kiota.ApiException;
 import okhttp3.FormBody;
 import okhttp3.OkHttpClient;
 import okhttp3.Request;
+import tools.jackson.databind.JsonNode;
 import tools.jackson.databind.ObjectMapper;
 import tools.jackson.databind.node.JsonNodeType;
 
@@ -220,36 +221,54 @@ public class HttpTriggerFunctions {
         T get() throws Exception;
     }
 
+    /**
+     * Parses and validates request payload for <code>FillXfaData</code>.
+     *
+     * @param requestBody Raw HTTP request body content.
+     * @return Parsed fill request payload.
+     */
     private static FillRequest parseFillRequest(final String requestBody) {
+        final var rootNode = parseRequestBodyAsJson(requestBody);
+
+        final var templateNode = rootNode.path("templateBase64");
+        final var templateBase64 = templateNode.stringValue();
+        if (templateNode.getNodeType() != JsonNodeType.STRING || templateBase64 == null || templateBase64.isBlank()) {
+            throw new IllegalArgumentException("Request field 'templateBase64' must be a non-empty string.");
+        }
+
+        final var formDataNode = rootNode.path("formData");
+        if (!formDataNode.isObject()) {
+            throw new IllegalArgumentException("Request field 'formData' must be a JSON object.");
+        }
+
+        if (!formDataNode.has("data") || formDataNode.size() != 1 || !formDataNode.path("data").isObject()) {
+            throw new IllegalArgumentException("Request field 'formData' must contain only a 'data' object.");
+        }
+
+        return new FillRequest(templateBase64, formDataNode.toString());
+    }
+
+    /**
+     * Parses the request body into a JSON node and translates parsing failures into a caller-facing
+     * <code>IllegalArgumentException</code>.
+     *
+     * @param requestBody Raw HTTP request body content.
+     * @return Parsed JSON root node.
+     */
+    private static JsonNode parseRequestBodyAsJson(final String requestBody) {
         try {
-            final var rootNode = OBJECT_MAPPER.readTree(requestBody);
-
-            final var templateNode = rootNode.path("templateBase64");
-            final var templateBase64 = templateNode.stringValue();
-            if (templateNode.getNodeType() != JsonNodeType.STRING || templateBase64 == null || templateBase64.isBlank()) {
-                throw new IllegalArgumentException("Request field 'templateBase64' must be a non-empty string.");
-            }
-
-            final var formDataNode = rootNode.path("formData");
-            if (!formDataNode.isObject()) {
-                throw new IllegalArgumentException("Request field 'formData' must be a JSON object.");
-            }
-
-            final String formDataJson;
-            if (formDataNode.has("data") && formDataNode.size() == 1 && formDataNode.path("data").isObject()) {
-                formDataJson = formDataNode.toString();
-            } else {
-                final var normalizedRoot = OBJECT_MAPPER.createObjectNode();
-                normalizedRoot.set("data", formDataNode);
-                formDataJson = normalizedRoot.toString();
-            }
-
-            return new FillRequest(templateBase64, formDataJson);
+            return OBJECT_MAPPER.readTree(requestBody);
         } catch (RuntimeException e) {
             throw new IllegalArgumentException("Request body must be valid JSON.", e);
         }
     }
 
+    /**
+     * Request payload contract for <code>FillXfaData</code>.
+     *
+     * @param templateBase64 Base64-encoded source PDF content.
+     * @param formDataJson   JSON object string containing a single <code>data</code> object.
+     */
     private record FillRequest(String templateBase64, String formDataJson) {
     }
 

--- a/FunctionApp/src/main/java/app/djk/RestPdfFormFiller/projectExceptions/EmptyRequestBodyException.java
+++ b/FunctionApp/src/main/java/app/djk/RestPdfFormFiller/projectExceptions/EmptyRequestBodyException.java
@@ -1,5 +1,7 @@
 package app.djk.RestPdfFormFiller.projectExceptions;
 
 public class EmptyRequestBodyException extends IllegalArgumentException {
+    private static final long serialVersionUID = 1L;
+
     public EmptyRequestBodyException() { super(); }
 }

--- a/FunctionApp/src/main/java/app/djk/RestPdfFormFiller/projectExceptions/InvalidReturnDataFormatException.java
+++ b/FunctionApp/src/main/java/app/djk/RestPdfFormFiller/projectExceptions/InvalidReturnDataFormatException.java
@@ -1,5 +1,7 @@
 package app.djk.RestPdfFormFiller.projectExceptions;
 
 public class InvalidReturnDataFormatException extends IllegalArgumentException {
+    private static final long serialVersionUID = 1L;
+
     public InvalidReturnDataFormatException() { super(); }
 }

--- a/FunctionApp/src/main/java/app/djk/RestPdfFormFiller/projectExceptions/InvalidSessionIdException.java
+++ b/FunctionApp/src/main/java/app/djk/RestPdfFormFiller/projectExceptions/InvalidSessionIdException.java
@@ -1,5 +1,7 @@
 package app.djk.RestPdfFormFiller.projectExceptions;
 
 public class InvalidSessionIdException extends IllegalArgumentException {
+    private static final long serialVersionUID = 1L;
+
     public InvalidSessionIdException() { super(); }
 }

--- a/FunctionApp/src/main/java/app/djk/RestPdfFormFiller/projectExceptions/InvalidXfaFormDataException.java
+++ b/FunctionApp/src/main/java/app/djk/RestPdfFormFiller/projectExceptions/InvalidXfaFormDataException.java
@@ -1,5 +1,7 @@
 package app.djk.RestPdfFormFiller.projectExceptions;
 
 public class InvalidXfaFormDataException extends IllegalArgumentException {
+    private static final long serialVersionUID = 1L;
+
     public InvalidXfaFormDataException() { super(); }
 }

--- a/FunctionApp/src/main/java/app/djk/RestPdfFormFiller/projectExceptions/InvalidXfaFormException.java
+++ b/FunctionApp/src/main/java/app/djk/RestPdfFormFiller/projectExceptions/InvalidXfaFormException.java
@@ -1,5 +1,7 @@
 package app.djk.RestPdfFormFiller.projectExceptions;
 
 public class InvalidXfaFormException extends IllegalArgumentException {
+    private static final long serialVersionUID = 1L;
+
     public InvalidXfaFormException() { super(); }
 }


### PR DESCRIPTION
This pull request introduces significant improvements to the PDF form-filling functionality, focusing on better handling of XFA forms, robust request validation, and improved error handling. The main changes include refactoring the XFA form filling API to use byte arrays, implementing strict request parsing and validation for form filling, and adding serialVersionUIDs to custom exceptions for serialization compatibility. Compiler settings are also tightened to enforce stricter code quality.

**PDF Form Filling Improvements:**

* Refactored the `fillXfaForm` method in `RestPdfApi` to accept and return byte arrays instead of streams, simplifying usage and making the API safer and more predictable. The method now checks for valid XFA forms before processing and returns the filled PDF as a byte array. [[1]](diffhunk://#diff-0eb460ad09035dc14b5765147f97b2cdb0698d27443a22fa4740834fb7e3f38dL84-R93) [[2]](diffhunk://#diff-0eb460ad09035dc14b5765147f97b2cdb0698d27443a22fa4740834fb7e3f38dL96-R102)

* Updated the HTTP trigger in `HttpTriggerFunctions` to parse incoming requests for a Base64-encoded PDF and JSON form data, decode and validate the inputs, and return the filled PDF as a Base64-encoded string.

**Request Validation and Parsing:**

* Added a `parseFillRequest` method to strictly validate incoming JSON requests, ensuring the presence and correctness of `templateBase64` (must be a non-empty string) and `formData` (must be a JSON object). Introduced a `FillRequest` record to encapsulate parsed data.

**Error Handling and Exceptions:**

* Added `serialVersionUID` fields to all custom exception classes in `projectExceptions` to ensure compatibility with Java serialization. [[1]](diffhunk://#diff-fb90670bcfb502570677ae67040f1d9e6ee62848539f745b511d382edc3d42fcR4-R5) [[2]](diffhunk://#diff-0ffa7d9f85f147df11b5daa2d47f57805c6b1d39f47a1b16a52ee1723d22a7e9R4-R5) [[3]](diffhunk://#diff-e3302b04de4870732a8c9df8fe01d26cd4a79f75fe45a72ebe8408e5c158c850R4-R5) [[4]](diffhunk://#diff-6a04c87296bb477321970b9a875f8956db9c80fc9440b9ee0234faeae07a168cR4-R5) [[5]](diffhunk://#diff-2c406563bcaec7b05b75e66dc37afc9f7d4ad40d2973b5c47db143b153c794e3R4-R5)

**Build and Code Quality:**

* Updated Maven compiler plugin settings in `pom.xml` to enable all warnings and deprecation messages, fail on warnings, and apply `-Xlint:all` for stricter code quality enforcement.

**Dependency and Import Updates:**

* Added missing imports for Jackson and related utilities to support the new JSON parsing and validation logic. [[1]](diffhunk://#diff-65fbd28909749b50078387a5bdba3437b9941e9dd7ca7bb9b620b968e3093a44R20-R23) [[2]](diffhunk://#diff-0eb460ad09035dc14b5765147f97b2cdb0698d27443a22fa4740834fb7e3f38dL14-R18)