### PR TITLE
Dependency security updates and minimal transitive pinning

### DIFF
--- a/FunctionApp/pom.xml
+++ b/FunctionApp/pom.xml
@@ -15,11 +15,11 @@
         <java.version>21</java.version>
         <functionAppName>RestPdfFormFiller-1654224697708</functionAppName>
         <netty.version>4.1.133.Final</netty.version>
-        <tools.jackson.version>3.1.4</tools.jackson.version>
-        <com.fasterxml.jackson.core.version>2.18.6</com.fasterxml.jackson.core.version>
+        <tools.jackson.version>3.2.0</tools.jackson.version>
+        <com.fasterxml.jackson.core.version>2.22.0</com.fasterxml.jackson.core.version>
         <bouncycastle.version>1.84</bouncycastle.version>
-        <kiota.abstractions.version>1.9.1</kiota.abstractions.version>
-        <opentelemetry.api.version>1.62.0</opentelemetry.api.version>
+        <kiota.abstractions.version>1.9.3</kiota.abstractions.version>
+        <opentelemetry.api.version>1.63.0</opentelemetry.api.version>
     </properties>
 
     <dependencyManagement>
@@ -69,11 +69,6 @@
                 <artifactId>opentelemetry-api</artifactId>
                 <version>${opentelemetry.api.version}</version>
             </dependency>
-            <dependency>
-                <groupId>org.bouncycastle</groupId>
-                <artifactId>bcprov-jdk18on</artifactId>
-                <version>${bouncycastle.version}</version>
-            </dependency>
         </dependencies>
     </dependencyManagement>
 
@@ -81,12 +76,12 @@
         <dependency>
             <groupId>com.microsoft.azure.functions</groupId>
             <artifactId>azure-functions-java-library</artifactId>
-            <version>3.2.3</version>
+            <version>3.3.0</version>
         </dependency>
         <dependency>
             <groupId>com.microsoft.graph</groupId>
             <artifactId>microsoft-graph</artifactId>
-            <version>6.62.0</version>
+            <version>6.65.0</version>
         </dependency>
         <dependency>
             <groupId>com.azure</groupId>
@@ -97,7 +92,7 @@
         <dependency>
             <groupId>com.github.librepdf</groupId>
             <artifactId>openpdf</artifactId>
-            <version>3.0.2</version>
+            <version>3.0.5</version>
         </dependency>
         <dependency>
             <groupId>org.bouncycastle</groupId>
@@ -112,7 +107,7 @@
         <dependency>
             <groupId>tools.jackson.dataformat</groupId>
             <artifactId>jackson-dataformat-xml</artifactId>
-            <version>3.1.0</version>
+            <version>3.2.0</version>
         </dependency>
 
 
@@ -120,14 +115,14 @@
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter</artifactId>
-            <version>6.0.3</version>
+            <version>6.1.1</version>
             <scope>test</scope>
         </dependency>
 
         <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
-            <version>5.22.0</version>
+            <version>5.23.0</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/FunctionApp/pom.xml
+++ b/FunctionApp/pom.xml
@@ -14,7 +14,68 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <java.version>21</java.version>
         <functionAppName>RestPdfFormFiller-1654224697708</functionAppName>
+        <netty.version>4.1.133.Final</netty.version>
+        <tools.jackson.version>3.1.4</tools.jackson.version>
+        <com.fasterxml.jackson.core.version>2.18.6</com.fasterxml.jackson.core.version>
+        <bouncycastle.version>1.84</bouncycastle.version>
+        <kiota.abstractions.version>1.9.1</kiota.abstractions.version>
+        <opentelemetry.api.version>1.62.0</opentelemetry.api.version>
     </properties>
+
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>io.netty</groupId>
+                <artifactId>netty-codec-http</artifactId>
+                <version>${netty.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.netty</groupId>
+                <artifactId>netty-codec-http2</artifactId>
+                <version>${netty.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.netty</groupId>
+                <artifactId>netty-codec</artifactId>
+                <version>${netty.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.netty</groupId>
+                <artifactId>netty-codec-dns</artifactId>
+                <version>${netty.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.netty</groupId>
+                <artifactId>netty-handler-proxy</artifactId>
+                <version>${netty.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>tools.jackson.core</groupId>
+                <artifactId>jackson-core</artifactId>
+                <version>${tools.jackson.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.fasterxml.jackson.core</groupId>
+                <artifactId>jackson-core</artifactId>
+                <version>${com.fasterxml.jackson.core.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.microsoft.kiota</groupId>
+                <artifactId>microsoft-kiota-abstractions</artifactId>
+                <version>${kiota.abstractions.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.opentelemetry</groupId>
+                <artifactId>opentelemetry-api</artifactId>
+                <version>${opentelemetry.api.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.bouncycastle</groupId>
+                <artifactId>bcprov-jdk18on</artifactId>
+                <version>${bouncycastle.version}</version>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
 
     <dependencies>
         <dependency>
@@ -41,12 +102,12 @@
         <dependency>
             <groupId>org.bouncycastle</groupId>
             <artifactId>bcutil-jdk18on</artifactId>
-            <version>1.83</version>
+            <version>${bouncycastle.version}</version>
         </dependency>
         <dependency>
             <groupId>tools.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>3.1.4</version>
+            <version>${tools.jackson.version}</version>
         </dependency>
         <dependency>
             <groupId>tools.jackson.dataformat</groupId>


### PR DESCRIPTION
This pull request updates the `FunctionApp/pom.xml` file to modernize dependencies, improve maintainability, and enhance compatibility. The main changes include adding a `dependencyManagement` section for centralized version control, updating several dependency versions, and introducing new version properties.

**Dependency management improvements:**

* Added a `<dependencyManagement>` section to centralize and control dependency versions for `netty`, `jackson`, `kiota`, and `opentelemetry` libraries. This helps ensure consistent versions across the project and simplifies future upgrades.

**Dependency version updates:**

* Upgraded core dependencies such as `azure-functions-java-library` (to `3.3.0`), `microsoft-graph` (to `6.65.0`), `openpdf` (to `3.0.5`), and `bcutil-jdk18on` (to `1.84`).
* Updated Jackson-related dependencies (`jackson-databind` to `3.2.0`, `jackson-dataformat-xml` to `3.2.0`) and switched to using version properties for easier updates.
* Bumped test dependencies: `junit-jupiter` to `6.1.1` and `mockito-core` to `5.23.0`.

**New version properties:**

* Introduced properties for `netty.version`, `tools.jackson.version`, `com.fasterxml.jackson.core.version`, `bouncycastle.version`, `kiota.abstractions.version`, and `opentelemetry.api.version` to simplify version management.