### PR TITLE
dedup workflows

### DIFF
--- a/.github/actions/java-build/action.yml
+++ b/.github/actions/java-build/action.yml
@@ -1,0 +1,39 @@
+name: Java Build
+
+description: Setup Java and run Maven build for the FunctionApp project.
+
+inputs:
+  package-directory:
+    description: Directory that contains pom.xml.
+    required: true
+  java-version:
+    description: Java version to install.
+    required: true
+  include-jacoco-report:
+    description: Whether to run jacoco:report in the Maven command.
+    required: false
+    default: 'false'
+
+runs:
+  using: composite
+  steps:
+    - name: Setup Java Sdk ${{ inputs.java-version }}
+      uses: actions/setup-java@v4
+      with:
+        distribution: microsoft
+        java-version: ${{ inputs.java-version }}
+        cache: maven
+
+    - name: Build with Maven (including tests)
+      if: ${{ inputs.include-jacoco-report != 'true' }}
+      shell: pwsh
+      run: |
+        # `mvn clean package` runs unit tests as part of the Maven lifecycle.
+        mvn -B clean package --file "${{ inputs.package-directory }}/pom.xml"
+
+    - name: Build with Maven and generate JaCoCo report
+      if: ${{ inputs.include-jacoco-report == 'true' }}
+      shell: pwsh
+      run: |
+        # `mvn clean package` runs unit tests as part of the Maven lifecycle.
+        mvn -B clean package jacoco:report --file "${{ inputs.package-directory }}/pom.xml"

--- a/.github/actions/java-build/action.yml
+++ b/.github/actions/java-build/action.yml
@@ -18,7 +18,7 @@ runs:
   using: composite
   steps:
     - name: Setup Java SDK ${{ inputs.java-version }}
-      uses: actions/setup-java@v4
+      uses: actions/setup-java@1bcf9fb12cf4aa7d266a90ae39939e61372fe520 # v5.4.0
       with:
         distribution: microsoft
         java-version: ${{ inputs.java-version }}

--- a/.github/actions/java-build/action.yml
+++ b/.github/actions/java-build/action.yml
@@ -1,6 +1,6 @@
 name: Java Build
 
-description: Setup Java and run Maven build for the FunctionApp project.
+description: Setup Java and run a Maven build (optionally generating a JaCoCo report) for the project in package-directory.
 
 inputs:
   package-directory:
@@ -17,7 +17,7 @@ inputs:
 runs:
   using: composite
   steps:
-    - name: Setup Java Sdk ${{ inputs.java-version }}
+    - name: Setup Java SDK ${{ inputs.java-version }}
       uses: actions/setup-java@v4
       with:
         distribution: microsoft

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -19,7 +19,6 @@ jobs:
 
   analyze:
     needs: checkChanges
-    if: ${{ needs.checkChanges.outputs.functionApp == 'true' }}
     name: Analyze
     runs-on: windows-latest
     timeout-minutes: 30
@@ -37,23 +36,27 @@ jobs:
 
       # Initializes the CodeQL tools for scanning.
       - name: Initialize CodeQL
+        if: ${{ github.event_name == 'schedule' || needs.checkChanges.outputs.functionApp == 'true' }}
         uses: github/codeql-action/init@54f647b7e1bb85c95cddabcd46b0c578ec92bc1a # v4.36.3
         with:
           languages: ${{ matrix.language }}
 
-      # AFAIk, this is unavoidable, since the CodeQL actions
-      # must be run in the same job as build actions.
-      - name: Setup Java Sdk ${{ env.JAVA_VERSION }}
-        uses: actions/setup-java@1bcf9fb12cf4aa7d266a90ae39939e61372fe520 # v5.4.0
-        with:
-          distribution: 'microsoft'
-          java-version: ${{ env.JAVA_VERSION }}
-          cache: maven
-
+      # CodeQL init, build, and analyze must stay in this same job.
       - name: Build with Maven
-        run: mvn -B package --file ${{ env.PACKAGE_DIRECTORY }}/pom.xml
+        if: ${{ github.event_name == 'schedule' || needs.checkChanges.outputs.functionApp == 'true' }}
+        uses: ./.github/actions/java-build
+        with:
+          package-directory: ${{ env.PACKAGE_DIRECTORY }}
+          java-version: ${{ env.JAVA_VERSION }}
+          include-jacoco-report: 'false'
 
       - name: Perform CodeQL Analysis
+        if: ${{ github.event_name == 'schedule' || needs.checkChanges.outputs.functionApp == 'true' }}
         uses: github/codeql-action/analyze@54f647b7e1bb85c95cddabcd46b0c578ec92bc1a # v4.36.3
         with:
           category: "/language:${{matrix.language}}"
+
+      - name: CodeQL Not Applicable
+        if: ${{ github.event_name != 'schedule' && needs.checkChanges.outputs.functionApp != 'true' }}
+        shell: pwsh
+        run: Write-Host 'Skipping CodeQL analysis because this change does not touch FunctionApp.'

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -33,18 +33,18 @@ jobs:
 
     steps:
       - name: Checkout Code
-        uses: actions/checkout@v4
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       # Initializes the CodeQL tools for scanning.
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@v3
+        uses: github/codeql-action/init@54f647b7e1bb85c95cddabcd46b0c578ec92bc1a # v4.36.3
         with:
           languages: ${{ matrix.language }}
 
       # AFAIk, this is unavoidable, since the CodeQL actions
       # must be run in the same job as build actions.
       - name: Setup Java Sdk ${{ env.JAVA_VERSION }}
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@1bcf9fb12cf4aa7d266a90ae39939e61372fe520 # v5.4.0
         with:
           distribution: 'microsoft'
           java-version: ${{ env.JAVA_VERSION }}
@@ -54,6 +54,6 @@ jobs:
         run: mvn -B package --file ${{ env.PACKAGE_DIRECTORY }}/pom.xml
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@v3
+        uses: github/codeql-action/analyze@54f647b7e1bb85c95cddabcd46b0c578ec92bc1a # v4.36.3
         with:
           category: "/language:${{matrix.language}}"

--- a/.github/workflows/dependencyCheck.yml
+++ b/.github/workflows/dependencyCheck.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: windows-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Run updateDependencies.ps1
         run: .github/resources/updateDependencies.ps1

--- a/.github/workflows/filter-changes.yml
+++ b/.github/workflows/filter-changes.yml
@@ -17,11 +17,11 @@ jobs:
       functionApp: ${{ steps.filter.outputs.functionApp }}
     steps:
       - name: 'Checkout GitHub Action'
-        uses: actions/checkout@v4
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         
       - name: filter
         id: filter
-        uses: dorny/paths-filter@v3
+        uses: dorny/paths-filter@7b450fff21473bca461d4b92ce414b9d0420d706 # v4.0.2
         with:
           filters: |
             functionApp:

--- a/.github/workflows/filter-changes.yml
+++ b/.github/workflows/filter-changes.yml
@@ -26,3 +26,7 @@ jobs:
           filters: |
             functionApp:
               - 'FunctionApp/**'
+              - '.github/actions/java-build/action.yml'
+              - '.github/workflows/codeql.yml'
+              - '.github/workflows/filter-changes.yml'
+              - '.github/workflows/maven.yml'

--- a/.github/workflows/main_restpdfformfiller(dev).yml
+++ b/.github/workflows/main_restpdfformfiller(dev).yml
@@ -20,20 +20,11 @@ jobs:
       - name: 'Checkout GitHub Action'
         uses: actions/checkout@v4
 
-      - name: Setup Java Sdk ${{ env.JAVA_VERSION }}
-        uses: actions/setup-java@v4
+      - name: Build with Maven (including tests)
+        uses: ./.github/actions/java-build
         with:
-          distribution: 'microsoft'
+          package-directory: ${{ env.PACKAGE_DIRECTORY }}
           java-version: ${{ env.JAVA_VERSION }}
-          cache: maven
-
-      - name: 'Restore Project Dependencies Using Mvn'
-        # `mvn clean package` runs unit tests as part of the Maven lifecycle.
-        shell: pwsh
-        run: |
-          pushd './${{ env.PACKAGE_DIRECTORY }}'
-          mvn clean package
-          popd
 
       - name: 'Run Azure Functions Action'
         uses: Azure/functions-action@v1

--- a/.github/workflows/main_restpdfformfiller(dev).yml
+++ b/.github/workflows/main_restpdfformfiller(dev).yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: windows-latest
     steps:
       - name: 'Checkout GitHub Action'
-        uses: actions/checkout@v4
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Build with Maven (including tests)
         uses: ./.github/actions/java-build
@@ -27,7 +27,7 @@ jobs:
           java-version: ${{ env.JAVA_VERSION }}
 
       - name: 'Run Azure Functions Action'
-        uses: Azure/functions-action@v1
+        uses: Azure/functions-action@bc63708cc6539760eea18d8a7de4ce8ef5fdf593 # v1.5.6
         id: fa
         with:
           app-name: ${{ env.AZURE_FUNCTIONAPP_NAME }}
@@ -39,6 +39,6 @@ jobs:
         # Generate GitHub Maven Dependency Tree
         # https://github.com/marketplace/actions/maven-dependency-tree-dependency-submission
       - name: Submit Dependency Snapshot
-        uses: advanced-security/maven-dependency-submission-action@v4
+        uses: advanced-security/maven-dependency-submission-action@b275d12641ac2d2108b2cbb7598b154ad2f2cee8 # v5.0.0
         with:
           directory: './${{ env.PACKAGE_DIRECTORY }}'

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -25,16 +25,12 @@ jobs:
       - name: 'Checkout GitHub Action'
         uses: actions/checkout@v4
 
-      - name: Setup Java Sdk ${{ env.JAVA_VERSION }}
-        uses: actions/setup-java@v4
-        with:
-          distribution: 'microsoft'
-          java-version: ${{ env.JAVA_VERSION }}
-          cache: maven
-
       - name: Build, Test, and Generate JaCoCo Report
-        # `mvn clean package` runs unit tests as part of the Maven lifecycle.
-        run: mvn -B clean package jacoco:report --file ${{ env.PACKAGE_DIRECTORY }}/pom.xml
+        uses: ./.github/actions/java-build
+        with:
+          package-directory: ${{ env.PACKAGE_DIRECTORY }}
+          java-version: ${{ env.JAVA_VERSION }}
+          include-jacoco-report: 'true'
 
       - name: Summarize JaCoCo Coverage
         id: coverage

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -7,7 +7,6 @@ on:
   pull_request:
     branches: [ main ]
   workflow_dispatch:
-  workflow_call:
 
 permissions:
   contents: read
@@ -23,7 +22,7 @@ jobs:
     runs-on: windows-latest
     steps:
       - name: 'Checkout GitHub Action'
-        uses: actions/checkout@v4
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Build, Test, and Generate JaCoCo Report
         uses: ./.github/actions/java-build
@@ -70,7 +69,7 @@ jobs:
 
       - name: Comment Coverage on PR
         if: ${{ github.event_name == 'pull_request' }}
-        uses: actions/github-script@v7
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           script: |
             const marker = '<!-- jacoco-coverage-summary -->';
@@ -110,7 +109,7 @@ jobs:
             }
 
       - name: Upload JaCoCo Report Artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: jacoco-report
           path: ${{ env.PACKAGE_DIRECTORY }}/target/site/jacoco


### PR DESCRIPTION
This pull request introduces a new reusable composite GitHub Action for building Java projects with Maven, and refactors several CI workflows to use this action. It also updates all GitHub Actions to use explicit, version-pinned commit SHAs for improved security and reproducibility. The most significant changes are grouped below.

**Reusable Java Build Action:**

- Added a new composite action at `.github/actions/java-build/action.yml` to standardize Java setup and Maven builds, with optional JaCoCo report generation. This action accepts configurable inputs for package directory, Java version, and JaCoCo report inclusion.

**Workflow Refactoring to Use Composite Action:**

- Refactored `main_restpdfformfiller(dev).yml` and `maven.yml` workflows to use the new `java-build` composite action, simplifying Java build/test steps and centralizing configuration. [[1]](diffhunk://#diff-e46d5ec91c5cd1a239b04d0b6c2954aa2515e3c04a0874bef123b9d07e491a7cL21-R30) [[2]](diffhunk://#diff-5dbf1a803ecc13ff945a08ed3eb09149a83615e83f15320550af8e3a91976446L26-R32)

**Security and Maintenance Improvements:**

- Updated all GitHub Actions in workflow files to use explicit commit SHAs instead of version tags, reducing the risk of supply chain attacks and ensuring deterministic builds. This includes actions such as `actions/checkout`, `actions/setup-java`, `github/codeql-action`, `dorny/paths-filter`, `Azure/functions-action`, `advanced-security/maven-dependency-submission-action`, `actions/github-script`, and `actions/upload-artifact`. [[1]](diffhunk://#diff-12783128521e452af0cfac94b99b8d250413c516ec71fe6d97dbea666ff7ba27L36-R47) [[2]](diffhunk://#diff-12783128521e452af0cfac94b99b8d250413c516ec71fe6d97dbea666ff7ba27L57-R57) [[3]](diffhunk://#diff-ae82b1b740e7f12fbd06026ffbc75124e461f34f770fb5c50267feba7e7e39efL20-R20) [[4]](diffhunk://#diff-559dbd82b1e323bf0dcac6082953f292c948a8cd691c11b2568a575eb8d0e5d3L20-R24) [[5]](diffhunk://#diff-e46d5ec91c5cd1a239b04d0b6c2954aa2515e3c04a0874bef123b9d07e491a7cL21-R30) [[6]](diffhunk://#diff-e46d5ec91c5cd1a239b04d0b6c2954aa2515e3c04a0874bef123b9d07e491a7cL51-R42) [[7]](diffhunk://#diff-5dbf1a803ecc13ff945a08ed3eb09149a83615e83f15320550af8e3a91976446L26-R32) [[8]](diffhunk://#diff-5dbf1a803ecc13ff945a08ed3eb09149a83615e83f15320550af8e3a91976446L77-R72) [[9]](diffhunk://#diff-5dbf1a803ecc13ff945a08ed3eb09149a83615e83f15320550af8e3a91976446L117-R112)

**Workflow Configuration Adjustments:**

- Removed the unused `workflow_call` trigger from `maven.yml` to clean up workflow configuration.