### PR TITLE
Update Java version and Azure auth

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -10,7 +10,7 @@ on:
     - cron: '29 3 * * 2'
 
 env:
-  JAVA_VERSION: '21'
+  JAVA_VERSION: '25'
   PACKAGE_DIRECTORY: 'FunctionApp'
 
 jobs:

--- a/.github/workflows/main_restpdfformfiller(dev).yml
+++ b/.github/workflows/main_restpdfformfiller(dev).yml
@@ -11,7 +11,7 @@ on:
 env:
   AZURE_FUNCTIONAPP_NAME: restpdfformfiller # set this to your function app name on Azure
   PACKAGE_DIRECTORY: 'FunctionApp' # set this to the directory which contains pom.xml file
-  JAVA_VERSION: '21' # set this to the java version to use
+  JAVA_VERSION: '25' # set this to the java version to use
 
 jobs:
   deploy-and-submit-dependencies:

--- a/.github/workflows/main_restpdfformfiller(dev).yml
+++ b/.github/workflows/main_restpdfformfiller(dev).yml
@@ -16,6 +16,9 @@ env:
 jobs:
   deploy-and-submit-dependencies:
     runs-on: windows-latest
+    permissions:
+      id-token: write
+      contents: read
     steps:
       - name: 'Checkout GitHub Action'
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
@@ -26,13 +29,19 @@ jobs:
           package-directory: ${{ env.PACKAGE_DIRECTORY }}
           java-version: ${{ env.JAVA_VERSION }}
 
+      - name: Azure Login (OIDC)
+        uses: Azure/login@532459ea530d8321f2fb9bb10d1e0bcf23869a43 # v3.0.0
+        with:
+          client-id: ${{ secrets.AZURE_CLIENT_ID }}
+          tenant-id: ${{ secrets.AZURE_TENANT_ID }}
+          subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+
       - name: 'Run Azure Functions Action'
         uses: Azure/functions-action@bc63708cc6539760eea18d8a7de4ce8ef5fdf593 # v1.5.6
         id: fa
         with:
           app-name: ${{ env.AZURE_FUNCTIONAPP_NAME }}
           slot-name: 'dev'
-          publish-profile: ${{ secrets.AZUREAPPSERVICE_PUBLISHPROFILE_2809551214454B81BB4D28673CCAEE70 }}
           package: ${{ env.PACKAGE_DIRECTORY }}
           respect-pom-xml: true
 

--- a/.github/workflows/main_restpdfformfiller(dev).yml
+++ b/.github/workflows/main_restpdfformfiller(dev).yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: windows-latest
     permissions:
       id-token: write
-      contents: read
+      contents: write
     steps:
       - name: 'Checkout GitHub Action'
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -14,7 +14,7 @@ permissions:
 
 env:
   PACKAGE_DIRECTORY: 'FunctionApp' # set this to the directory which contains pom.xml file
-  JAVA_VERSION: '21' # set this to the java version to use
+  JAVA_VERSION: '25' # set this to the java version to use
 
 jobs:
   

--- a/FunctionApp/pom.xml
+++ b/FunctionApp/pom.xml
@@ -140,7 +140,7 @@
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>3.14.1</version>
                 <configuration>
-                    <release>25</release>
+                    <release>${java.version}</release>
                     <encoding>${project.build.sourceEncoding}</encoding>
                     <showWarnings>true</showWarnings>
                     <showDeprecation>true</showDeprecation>
@@ -174,7 +174,7 @@
                     <runtime>
                         <!-- runtime os, could be windows, linux or docker-->
                         <os>windows</os>
-                        <javaVersion>25</javaVersion>
+                        <javaVersion>${java.version}</javaVersion>
                         <!-- for docker function, please set the following parameters -->
                         <!-- <image>[hub-user/]repo-name[:tag]</image> -->
                         <!-- <serverId></serverId> -->

--- a/FunctionApp/pom.xml
+++ b/FunctionApp/pom.xml
@@ -211,7 +211,7 @@
             <plugin>
                 <groupId>org.jacoco</groupId>
                 <artifactId>jacoco-maven-plugin</artifactId>
-                <version>0.8.12</version>
+                <version>0.8.15</version>
                 <executions>
                     <execution>
                         <id>prepare-agent</id>

--- a/FunctionApp/pom.xml
+++ b/FunctionApp/pom.xml
@@ -12,7 +12,7 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <java.version>21</java.version>
+        <java.version>25</java.version>
         <functionAppName>RestPdfFormFiller-1654224697708</functionAppName>
         <netty.version>4.1.133.Final</netty.version>
         <tools.jackson.version>3.2.0</tools.jackson.version>
@@ -140,7 +140,7 @@
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>3.14.1</version>
                 <configuration>
-                    <release>21</release>
+                    <release>25</release>
                     <encoding>${project.build.sourceEncoding}</encoding>
                     <showWarnings>true</showWarnings>
                     <showDeprecation>true</showDeprecation>
@@ -174,7 +174,7 @@
                     <runtime>
                         <!-- runtime os, could be windows, linux or docker-->
                         <os>windows</os>
-                        <javaVersion>21</javaVersion>
+                        <javaVersion>25</javaVersion>
                         <!-- for docker function, please set the following parameters -->
                         <!-- <image>[hub-user/]repo-name[:tag]</image> -->
                         <!-- <serverId></serverId> -->


### PR DESCRIPTION
This pull request updates the project to use Java 25 throughout the build, deployment, and workflow configurations. It also improves the Azure deployment workflow by switching to OpenID Connect (OIDC) authentication for enhanced security and removing the need for a publish profile secret.

Key changes include:

**Java Version Upgrade:**
* Updated the Java version from 21 to 25 in all workflow files (`.github/workflows/codeql.yml`, `.github/workflows/main_restpdfformfiller(dev).yml`, `.github/workflows/maven.yml`), and in the `FunctionApp/pom.xml` file for build, compiler plugin, and runtime configuration. [[1]](diffhunk://#diff-12783128521e452af0cfac94b99b8d250413c516ec71fe6d97dbea666ff7ba27L13-R13) [[2]](diffhunk://#diff-e46d5ec91c5cd1a239b04d0b6c2954aa2515e3c04a0874bef123b9d07e491a7cL14-R21) [[3]](diffhunk://#diff-5dbf1a803ecc13ff945a08ed3eb09149a83615e83f15320550af8e3a91976446L17-R17) [[4]](diffhunk://#diff-ca673af0796aa914b76cdde7df9dcc8e828268f8d988905b44ff82a869333dabL15-R15) [[5]](diffhunk://#diff-ca673af0796aa914b76cdde7df9dcc8e828268f8d988905b44ff82a869333dabL143-R143) [[6]](diffhunk://#diff-ca673af0796aa914b76cdde7df9dcc8e828268f8d988905b44ff82a869333dabL177-R177)

**Azure Deployment Workflow Improvements:**
* Added OIDC-based Azure login (`Azure/login` action) with required permissions and removed the need for the `publish-profile` secret in the deployment step, making the workflow more secure and maintainable. [[1]](diffhunk://#diff-e46d5ec91c5cd1a239b04d0b6c2954aa2515e3c04a0874bef123b9d07e491a7cL14-R21) [[2]](diffhunk://#diff-e46d5ec91c5cd1a239b04d0b6c2954aa2515e3c04a0874bef123b9d07e491a7cR32-L35)