### PR TITLE
fix pom

### DIFF
--- a/.github/workflows/main_restpdfformfiller(dev).yml
+++ b/.github/workflows/main_restpdfformfiller(dev).yml
@@ -39,7 +39,7 @@ jobs:
 
       - name: 'Run Azure Functions Action'
         uses: Azure/functions-action@bc63708cc6539760eea18d8a7de4ce8ef5fdf593 # v1.5.6
-        id: fa
+        id: deploy-to-function-app
         with:
           app-name: ${{ env.AZURE_FUNCTIONAPP_NAME }}
           slot-name: ${{ env.AZURE_FUNCTIONAPP_SLOT_NAME }}

--- a/FunctionApp/pom.xml
+++ b/FunctionApp/pom.xml
@@ -13,7 +13,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <java.version>25</java.version>
-        <functionAppName>RestPdfFormFiller-1654224697708</functionAppName>
+        <functionAppName>RestPdfFormFiller</functionAppName>
         <netty.version>4.1.133.Final</netty.version>
         <tools.jackson.version>3.2.0</tools.jackson.version>
         <com.fasterxml.jackson.core.version>2.22.0</com.fasterxml.jackson.core.version>


### PR DESCRIPTION
This pull request includes minor improvements to deployment configuration and project metadata. The main changes are:

Deployment workflow updates:
* Renamed the job step ID from `fa` to `deploy-to-function-app` in `.github/workflows/main_restpdfformfiller(dev).yml` for clearer identification during Azure Functions deployment.

Project metadata update:
* Updated the `functionAppName` property in `FunctionApp/pom.xml` to remove the timestamp suffix, standardizing the function app name to `RestPdfFormFiller`.