### PR TITLE
Trim azure-functions-maven-plugin config to package-only settings

### DIFF
--- a/FunctionApp/pom.xml
+++ b/FunctionApp/pom.xml
@@ -155,37 +155,10 @@
                 <artifactId>azure-functions-maven-plugin</artifactId>
                 <version>1.40.0</version>
                 <configuration>
-                    <!-- function app name -->
+                    <!-- Names the local staging folder target/azure-functions/<appName>, which the
+                         GitHub Actions deploy (respect-pom-xml) reads. Deploy targeting itself comes
+                         from the workflow app-name/slot-name, not from this pom. -->
                     <appName>${functionAppName}</appName>
-                    <!-- function app resource group -->
-                    <resourceGroup>java-functions-group</resourceGroup>
-                    <!-- function app service plan name -->
-                    <appServicePlanName>java-functions-app-service-plan</appServicePlanName>
-                    <!-- function app region-->
-                    <!-- refers https://github.com/microsoft/azure-maven-plugins/wiki/Azure-Functions:-Configuration-Details#supported-regions for all valid values -->
-                    <region>westus</region>
-                    <!-- function pricingTier, default to be consumption if not specified -->
-                    <!-- refers https://github.com/microsoft/azure-maven-plugins/wiki/Azure-Functions:-Configuration-Details#supported-pricing-tiers for all valid values -->
-                    <!-- <pricingTier></pricingTier> -->
-
-                    <!-- Whether to disable application insights, default is false -->
-                    <!-- refers https://github.com/microsoft/azure-maven-plugins/wiki/Azure-Functions:-Configuration-Details for all valid configurations for application insights-->
-                    <!-- <disableAppInsights></disableAppInsights> -->
-                    <runtime>
-                        <!-- runtime os, could be windows, linux or docker-->
-                        <os>windows</os>
-                        <javaVersion>${java.version}</javaVersion>
-                        <!-- for docker function, please set the following parameters -->
-                        <!-- <image>[hub-user/]repo-name[:tag]</image> -->
-                        <!-- <serverId></serverId> -->
-                        <!-- <registryUrl></registryUrl>  -->
-                    </runtime>
-                    <appSettings>
-                        <property>
-                            <name>FUNCTIONS_EXTENSION_VERSION</name>
-                            <value>~4</value>
-                        </property>
-                    </appSettings>
                 </configuration>
                 <executions>
                     <execution>


### PR DESCRIPTION
## Summary
The workflow deploys via `Azure/functions-action` (ZIP deploy) and never runs the `azure-functions:deploy` goal. Only `<appName>` is consumed by the `package` goal — it names `target/azure-functions/<appName>`, which `respect-pom-xml` reads. The rest were **deploy-only** settings with **stale values** that never matched the real Azure resources (`java-functions-group`/`westus` vs actual `PdfFormFiller`/`centralus`).

## Removed (deploy-only, unused in CI)
- `<resourceGroup>`, `<appServicePlanName>`, `<region>`
- `<runtime>`, `<appSettings>` (FUNCTIONS_EXTENSION_VERSION — set on the Azure app, not in the zip)

## Kept
- `<appName>${functionAppName}</appName>` — required by the `package` goal and `respect-pom-xml`

## Verification
`mvn clean package` produces an identical staging folder `target/azure-functions/RestPdfFormFiller/` (host.json, lib, all 4 functions, jar). No behavior change for the GitHub Actions deploy.