### PR TITLE
Switch function IO to binary for Power Automate integration

### DIFF
--- a/CustomConnector/PdfFormFiller.swagger.json
+++ b/CustomConnector/PdfFormFiller.swagger.json
@@ -2,8 +2,8 @@
     "swagger": "2.0",
     "info": {
       "title": "PdfFormFiller",
-      "description": "Allows filling and retrieving data from selected forms. (DEV VERSION)",
-      "version": "0.4"
+      "description": "Fills and reads data from XFA PDF forms. Files are exchanged as raw binary so SharePoint/OneDrive file content can be used directly in Power Automate. (DEV VERSION)",
+      "version": "0.5"
     },
     "host": "restpdfformfiller-dev.azurewebsites.net",
     "basePath": "/api/",
@@ -11,36 +11,37 @@
       "https"
     ],
     "consumes": [
-      "text/plain",
-      "application/json"
+      "application/json",
+      "application/octet-stream"
     ],
     "produces": [
       "application/json",
-      "application/xml"
+      "application/xml",
+      "application/pdf"
     ],
     "paths": {
       "/GetXfaData": {
         "post": {
           "responses": {
-            "400": {
-              "description": "Bad request."
-            },
-            "default": {
-              "description": "default",
+            "200": {
+              "description": "The XFA form data in the requested format.",
               "schema": {
                 "title": "formData",
                 "type": "string"
               }
+            },
+            "400": {
+              "description": "Bad request (missing/invalid format, empty body, or the file is not a valid PDF)."
             }
           },
           "summary": "Get XFA Form Data",
           "description": "Gets the data from the given XFA form.",
           "consumes": [
-            "text/plain"
+            "application/octet-stream"
           ],
           "produces": [
-            "application/xml",
-            "application/json"
+            "application/json",
+            "application/xml"
           ],
           "operationId": "GetXfaData",
           "parameters": [
@@ -59,15 +60,17 @@
               "name": "x-functions-key",
               "required": true,
               "in": "header",
-              "type": "string"
+              "type": "string",
+              "description": "Azure Functions key (interim auth while OAuth is being validated)."
             },
             {
-              "name": "pdfContentBase64",
-              "description": "File content in base64 (use body/$content from SharePoint Get file action)",
+              "name": "pdfContent",
+              "description": "Raw PDF file content (pass File Content from a SharePoint/OneDrive 'Get file content' action directly).",
               "in": "body",
               "required": true,
               "schema": {
-                "type": "string"
+                "type": "string",
+                "format": "binary"
               }
             }
           ]
@@ -76,19 +79,23 @@
       "/FillXfaData": {
         "post": {
           "responses": {
-            "400": {
-              "description": "Bad request."
-            },
-            "default": {
-              "description": "default",
+            "200": {
+              "description": "The filled PDF file.",
               "schema": {
-                "title": "formData",
-                "type": "string"
+                "title": "filledPdf",
+                "type": "string",
+                "format": "binary"
               }
+            },
+            "400": {
+              "description": "Bad request (invalid JSON, contract violation, or the template is not a valid XFA form)."
+            },
+            "409": {
+              "description": "Write conflict (patchMode 'failOnConflict' and a provided value would overwrite a different existing value)."
             }
           },
           "summary": "Fill XFA Form Data",
-          "description": "Fills the specified data into the given PDF/XFAF form.",
+          "description": "Fills the specified data into the given XFA PDF form and returns the filled PDF as a file.",
           "consumes": [
             "application/json"
           ],
@@ -98,31 +105,62 @@
           "operationId": "FillXfaData",
           "parameters": [
             {
-              "name": "pdfContentBase64",
-              "in": "header",
-              "type": "string",
-              "format": "bytes"
-            },
-            {
               "name": "x-functions-key",
               "required": true,
               "in": "header",
-              "type": "string"
+              "type": "string",
+              "description": "Azure Functions key (interim auth while OAuth is being validated)."
             },
             {
-              "name": "fillXfaBodyData",
+              "name": "fillRequest",
               "in": "body",
               "required": true,
               "schema": {
-                "x-ms-dynamic-schema": {
-                  "operationId": "GetXfaFormSchema",
-                  "parameters": {
-                    "pdfFormData": {
-                      "parameter": "pdfContentBase64"
-                    },
-                    "x-functions-key": {
-                      "parameter": "x-functions-key"
+                "type": "object",
+                "required": [
+                  "templateBase64",
+                  "formData"
+                ],
+                "properties": {
+                  "templateBase64": {
+                    "type": "string",
+                    "format": "byte",
+                    "description": "Source PDF. Pass File Content from a 'Get file content' action; Power Automate encodes it automatically."
+                  },
+                  "formData": {
+                    "type": "object",
+                    "required": [
+                      "data"
+                    ],
+                    "properties": {
+                      "data": {
+                        "type": "object",
+                        "description": "The XFA datasets 'data' object (e.g. { \"form1\": { \"Page1\": { \"SSN\": \"...\" } } })."
+                      }
                     }
+                  },
+                  "writeMode": {
+                    "type": "string",
+                    "default": "patch",
+                    "enum": [
+                      "patch",
+                      "put"
+                    ],
+                    "description": "patch merges into the existing form (omitted fields kept); put replaces the whole form (omitted fields cleared)."
+                  },
+                  "patchMode": {
+                    "type": "string",
+                    "enum": [
+                      "overwrite",
+                      "ifEmpty",
+                      "failOnConflict"
+                    ],
+                    "description": "Collision policy for provided fields under writeMode 'patch'. Invalid when writeMode is 'put'."
+                  },
+                  "validateOnly": {
+                    "type": "boolean",
+                    "default": false,
+                    "description": "If true, validate the request and return success/failure without producing a filled document."
                   }
                 }
               }
@@ -133,45 +171,41 @@
       "/GetXfaSchema": {
         "post": {
           "responses": {
-            "400": {
-              "description": "Bad request."
-            },
-            "default": {
-              "description": "default",
+            "200": {
+              "description": "JSON schema of the datasets in the given PDF.",
               "schema": {
                 "title": "formSchema",
                 "type": "string"
               }
+            },
+            "400": {
+              "description": "Bad request (empty body or the file is not a valid PDF)."
             }
           },
           "summary": "Get XFA Form Schema",
-          "description": "Gets JSON schema of datasets from given PDF document.",
+          "description": "Gets the JSON schema of datasets from the given PDF document.",
           "consumes": [
-            "text/plain"
+            "application/octet-stream"
           ],
           "produces": [
             "application/json"
           ],
           "parameters": [
             {
-              "name": "x-session-id",
-              "in": "header",
-              "type": "string",
-              "required": false
-            },
-            {
               "name": "x-functions-key",
               "required": true,
               "in": "header",
-              "type": "string"
+              "type": "string",
+              "description": "Azure Functions key (interim auth while OAuth is being validated)."
             },
             {
-              "name": "pdfFormData",
+              "name": "pdfContent",
+              "description": "Raw PDF file content (pass File Content from a SharePoint/OneDrive 'Get file content' action directly).",
               "in": "body",
-              "required": false,
+              "required": true,
               "schema": {
                 "type": "string",
-                "format": "bytes"
+                "format": "binary"
               }
             }
           ],

--- a/FunctionApp/src/main/java/app/djk/RestPdfFormFiller/functions/HttpTriggerFunctions.java
+++ b/FunctionApp/src/main/java/app/djk/RestPdfFormFiller/functions/HttpTriggerFunctions.java
@@ -44,12 +44,16 @@ public class HttpTriggerFunctions {
                     name = "req",
                     methods = {HttpMethod.POST},
                     authLevel = AuthorizationLevel.FUNCTION)
-            HttpRequestMessage<Optional<String>> request,
+            HttpRequestMessage<Optional<byte[]>> request,
             final ExecutionContext context) {
 
         return errorHandler(request, context, () -> {
-            // Checking if a body was received in the HTTP request.
-            final var requestBody = request.getBody().orElseThrow(EmptyRequestBodyException::new);
+            // The PDF arrives as the raw binary request body (no Base64), so a Power Automate flow can pass a
+            // SharePoint/OneDrive "Get file content" result straight through without any conversion.
+            final var requestBytes = request.getBody().orElseThrow(EmptyRequestBodyException::new);
+            if (requestBytes.length == 0) {
+                throw new EmptyRequestBodyException();
+            }
 
             // Return format supplied as URL query parameter. See RestPdfApi for valid formats.
             final var returnDataFormat = request.getQueryParameters().get("format");
@@ -58,8 +62,6 @@ public class HttpTriggerFunctions {
                 throw new InvalidReturnDataFormatException();
             }
 
-            // The function expects the PDF to be encoded in Base64 for safe transit over the internet.
-            final var requestBytes = Base64.getDecoder().decode(requestBody);
             context.getLogger().info("Request length (number of bytes): " + requestBytes.length);
 
             var datasetsString = RestPdfApi.getXfaDatasetNodeAsString(requestBytes);
@@ -76,13 +78,15 @@ public class HttpTriggerFunctions {
                     name = "req",
                     methods = {HttpMethod.POST},
                     authLevel = AuthorizationLevel.FUNCTION)
-            HttpRequestMessage<Optional<String>> request,
+            HttpRequestMessage<Optional<byte[]>> request,
             final ExecutionContext context) {
 
         return errorHandler(request, context, () -> {
-            final var requestBody = request.getBody().orElseThrow(EmptyRequestBodyException::new);
-            // The function expects the PDF to be encoded in Base64 for safe transit over the internet.
-            final var requestBytes = Base64.getDecoder().decode(requestBody);
+            // The PDF arrives as the raw binary request body (no Base64), matching the other read endpoint.
+            final var requestBytes = request.getBody().orElseThrow(EmptyRequestBodyException::new);
+            if (requestBytes.length == 0) {
+                throw new EmptyRequestBodyException();
+            }
             context.getLogger().info("Request length (number of bytes): " + requestBytes.length);
 
             final var dataSchema = DataFormatter.generateJsonSchema(RestPdfApi.getXfaDatasetNodeAsString(requestBytes));
@@ -119,9 +123,14 @@ public class HttpTriggerFunctions {
 
             final var filledPdfBytes = RestPdfApi.fillXfaForm(
                     templateBytes, fillRequest.formDataJson(), fillRequest.writeMode(), fillRequest.patchMode());
-            final var base64EncodedForm = Base64.getEncoder().encodeToString(filledPdfBytes);
 
-            return request.createResponseBuilder(HttpStatus.OK).body(base64EncodedForm).build();
+            // Return the filled PDF as raw binary (application/pdf) so Power Automate treats the response as a file
+            // that drops straight into a "Create file" action -- no Base64-to-binary conversion, and no risk of the
+            // document being corrupted by passing it through a JSON string layer.
+            return request.createResponseBuilder(HttpStatus.OK)
+                    .header("Content-Type", "application/pdf")
+                    .body(filledPdfBytes)
+                    .build();
         });
     }
 
@@ -169,6 +178,11 @@ public class HttpTriggerFunctions {
         } catch (IllegalArgumentException e) {
             return logAndRespond(request, context, Level.WARNING, HttpStatus.BAD_REQUEST,
                     "Invalid argument in request.", e);
+        } catch (java.io.IOException e) {
+            // Every request in this app is processed against in-memory PDF bytes, so an IOException here means the
+            // caller's PDF could not be parsed rather than a genuine infrastructure failure. Report it as a 400.
+            return logAndRespond(request, context, Level.WARNING, HttpStatus.BAD_REQUEST,
+                    "Invalid or corrupted PDF file.", e);
         } catch (Exception e) {
             return logAndRespond(request, context, Level.SEVERE, HttpStatus.INTERNAL_SERVER_ERROR,
                     "Request failed.", e);

--- a/FunctionApp/src/main/java/app/djk/RestPdfFormFiller/functions/HttpTriggerFunctions.java
+++ b/FunctionApp/src/main/java/app/djk/RestPdfFormFiller/functions/HttpTriggerFunctions.java
@@ -178,9 +178,11 @@ public class HttpTriggerFunctions {
         } catch (IllegalArgumentException e) {
             return logAndRespond(request, context, Level.WARNING, HttpStatus.BAD_REQUEST,
                     "Invalid argument in request.", e);
-        } catch (java.io.IOException e) {
+        } catch (java.io.IOException | javax.xml.transform.TransformerException e) {
             // Every request in this app is processed against in-memory PDF bytes, so an IOException here means the
-            // caller's PDF could not be parsed rather than a genuine infrastructure failure. Report it as a 400.
+            // caller's PDF could not be parsed rather than a genuine infrastructure failure. A TransformerException
+            // likewise means the caller's XFA dataset could not be serialized. Both are client-side problems, so
+            // report them as a 400 rather than letting them fall through to the generic 500.
             return logAndRespond(request, context, Level.WARNING, HttpStatus.BAD_REQUEST,
                     "Invalid or corrupted PDF file.", e);
         } catch (Exception e) {

--- a/FunctionApp/src/test/java/app/djk/RestPdfFormFiller/functions/HttpTriggerFunctionsTest.java
+++ b/FunctionApp/src/test/java/app/djk/RestPdfFormFiller/functions/HttpTriggerFunctionsTest.java
@@ -7,6 +7,7 @@ import com.microsoft.azure.functions.HttpStatus;
 import com.microsoft.azure.functions.HttpStatusType;
 import org.junit.jupiter.api.Test;
 
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Base64;
@@ -26,7 +27,7 @@ class HttpTriggerFunctionsTest {
     @Test
     void getXfaDataReturnsBadRequestWhenBodyMissing() {
         final var function = new HttpTriggerFunctions();
-        final var responseMocks = setupResponseMocks(Optional.<String>empty(), Map.of("format", "json"));
+        final var responseMocks = setupResponseMocks(Optional.<byte[]>empty(), Map.of("format", "json"));
 
         final var actualResponse = function.getXfaData(responseMocks.request(), responseMocks.context());
 
@@ -38,7 +39,7 @@ class HttpTriggerFunctionsTest {
     @Test
     void getXfaDataReturnsBadRequestWhenFormatIsInvalid() {
         final var function = new HttpTriggerFunctions();
-        final var responseMocks = setupResponseMocks(Optional.of("dGVzdA=="), Map.of("format", "yaml"));
+        final var responseMocks = setupResponseMocks(Optional.of(new byte[]{1, 2, 3}), Map.of("format", "yaml"));
 
         final var actualResponse = function.getXfaData(responseMocks.request(), responseMocks.context());
 
@@ -50,7 +51,7 @@ class HttpTriggerFunctionsTest {
     @Test
     void getXfaDataReturnsBadRequestWhenFormatIsMissing() {
         final var function = new HttpTriggerFunctions();
-        final var responseMocks = setupResponseMocks(Optional.of("dGVzdA=="), Map.of());
+        final var responseMocks = setupResponseMocks(Optional.of(new byte[]{1, 2, 3}), Map.of());
 
         final var actualResponse = function.getXfaData(responseMocks.request(), responseMocks.context());
 
@@ -62,7 +63,7 @@ class HttpTriggerFunctionsTest {
     @Test
     void getXfaSchemaReturnsBadRequestWhenBodyMissing() {
         final var function = new HttpTriggerFunctions();
-        final var responseMocks = setupResponseMocks(Optional.<String>empty(), Map.of());
+        final var responseMocks = setupResponseMocks(Optional.<byte[]>empty(), Map.of());
 
         final var actualResponse = function.getXfaSchema(responseMocks.request(), responseMocks.context());
 
@@ -72,15 +73,16 @@ class HttpTriggerFunctionsTest {
     }
 
     @Test
-    void getXfaSchemaReturnsBadRequestWhenBodyIsNotBase64() {
+    void getXfaSchemaReturnsBadRequestWhenBodyIsNotValidPdf() {
         final var function = new HttpTriggerFunctions();
-        final var responseMocks = setupResponseMocks(Optional.of("not base64"), Map.of());
+        final var responseMocks = setupResponseMocks(
+                Optional.of("not a pdf".getBytes(StandardCharsets.UTF_8)), Map.of());
 
         final var actualResponse = function.getXfaSchema(responseMocks.request(), responseMocks.context());
 
         assertSame(responseMocks.response(), actualResponse);
         verify(responseMocks.request()).createResponseBuilder(HttpStatus.BAD_REQUEST);
-        verify(responseMocks.builder()).body("Invalid argument in request.");
+        verify(responseMocks.builder()).body("Invalid or corrupted PDF file.");
     }
 
     @Test
@@ -225,82 +227,82 @@ class HttpTriggerFunctionsTest {
         verify(responseMocks.builder()).body("Request field 'formData' must contain only a 'data' object.");
     }
 
-        @Test
-        void fillXfaDataReturnsBadRequestWhenWriteModeIsInvalid() {
-                final var function = new HttpTriggerFunctions();
-                final var invalidPayload = """
-                                {
-                                    "templateBase64": "dGVzdA==",
-                                    "formData": {"data": {}},
-                                    "writeMode": "sideways"
-                                }
-                                """;
-                final var responseMocks = setupResponseMocks(Optional.of(invalidPayload), Map.of());
+    @Test
+    void fillXfaDataReturnsBadRequestWhenWriteModeIsInvalid() {
+        final var function = new HttpTriggerFunctions();
+        final var invalidPayload = """
+                {
+                    "templateBase64": "dGVzdA==",
+                    "formData": {"data": {}},
+                    "writeMode": "sideways"
+                }
+                """;
+        final var responseMocks = setupResponseMocks(Optional.of(invalidPayload), Map.of());
 
-                final var actualResponse = function.fillXfaData(responseMocks.request(), responseMocks.context());
+        final var actualResponse = function.fillXfaData(responseMocks.request(), responseMocks.context());
 
-                assertSame(responseMocks.response(), actualResponse);
-                verify(responseMocks.request()).createResponseBuilder(HttpStatus.BAD_REQUEST);
-                verify(responseMocks.builder()).body("Request field 'writeMode' must be one of the following strings: patch, put.");
-        }
+        assertSame(responseMocks.response(), actualResponse);
+        verify(responseMocks.request()).createResponseBuilder(HttpStatus.BAD_REQUEST);
+        verify(responseMocks.builder()).body("Request field 'writeMode' must be one of the following strings: patch, put.");
+    }
 
-        @Test
-        void fillXfaDataReturnsBadRequestWhenPatchModeIsInvalid() {
-                final var function = new HttpTriggerFunctions();
-                final var invalidPayload = """
-                                {
-                                    "templateBase64": "dGVzdA==",
-                                    "formData": {"data": {}},
-                                    "patchMode": "mergeMaybe"
-                                }
-                                """;
-                final var responseMocks = setupResponseMocks(Optional.of(invalidPayload), Map.of());
+    @Test
+    void fillXfaDataReturnsBadRequestWhenPatchModeIsInvalid() {
+        final var function = new HttpTriggerFunctions();
+        final var invalidPayload = """
+                {
+                    "templateBase64": "dGVzdA==",
+                    "formData": {"data": {}},
+                    "patchMode": "mergeMaybe"
+                }
+                """;
+        final var responseMocks = setupResponseMocks(Optional.of(invalidPayload), Map.of());
 
-                final var actualResponse = function.fillXfaData(responseMocks.request(), responseMocks.context());
+        final var actualResponse = function.fillXfaData(responseMocks.request(), responseMocks.context());
 
-                assertSame(responseMocks.response(), actualResponse);
-                verify(responseMocks.request()).createResponseBuilder(HttpStatus.BAD_REQUEST);
-                verify(responseMocks.builder()).body("Request field 'patchMode' must be one of the following strings: overwrite, ifEmpty, failOnConflict.");
-        }
+        assertSame(responseMocks.response(), actualResponse);
+        verify(responseMocks.request()).createResponseBuilder(HttpStatus.BAD_REQUEST);
+        verify(responseMocks.builder()).body("Request field 'patchMode' must be one of the following strings: overwrite, ifEmpty, failOnConflict.");
+    }
 
-        @Test
-        void fillXfaDataReturnsBadRequestWhenPatchModeSuppliedWithPut() {
-                final var function = new HttpTriggerFunctions();
-                final var invalidPayload = """
-                                {
-                                    "templateBase64": "dGVzdA==",
-                                    "formData": {"data": {}},
-                                    "writeMode": "put",
-                                    "patchMode": "ifEmpty"
-                                }
-                                """;
-                final var responseMocks = setupResponseMocks(Optional.of(invalidPayload), Map.of());
+    @Test
+    void fillXfaDataReturnsBadRequestWhenPatchModeSuppliedWithPut() {
+        final var function = new HttpTriggerFunctions();
+        final var invalidPayload = """
+                {
+                    "templateBase64": "dGVzdA==",
+                    "formData": {"data": {}},
+                    "writeMode": "put",
+                    "patchMode": "ifEmpty"
+                }
+                """;
+        final var responseMocks = setupResponseMocks(Optional.of(invalidPayload), Map.of());
 
-                final var actualResponse = function.fillXfaData(responseMocks.request(), responseMocks.context());
+        final var actualResponse = function.fillXfaData(responseMocks.request(), responseMocks.context());
 
-                assertSame(responseMocks.response(), actualResponse);
-                verify(responseMocks.request()).createResponseBuilder(HttpStatus.BAD_REQUEST);
-                verify(responseMocks.builder()).body("Request field 'patchMode' is only valid when 'writeMode' is 'patch'.");
-        }
+        assertSame(responseMocks.response(), actualResponse);
+        verify(responseMocks.request()).createResponseBuilder(HttpStatus.BAD_REQUEST);
+        verify(responseMocks.builder()).body("Request field 'patchMode' is only valid when 'writeMode' is 'patch'.");
+    }
 
-        @Test
-        void fillXfaDataReturnsBadRequestWhenValidateOnlyIsNotBoolean() {
-                final var function = new HttpTriggerFunctions();
-                final var invalidPayload = """
-                                {
-                                    "templateBase64": "dGVzdA==",
-                                    "formData": {"data": {}},
-                                    "validateOnly": "yes"
-                                }
-                                """;
-                final var responseMocks = setupResponseMocks(Optional.of(invalidPayload), Map.of());
+    @Test
+    void fillXfaDataReturnsBadRequestWhenValidateOnlyIsNotBoolean() {
+        final var function = new HttpTriggerFunctions();
+        final var invalidPayload = """
+                {
+                    "templateBase64": "dGVzdA==",
+                    "formData": {"data": {}},
+                    "validateOnly": "yes"
+                }
+                """;
+        final var responseMocks = setupResponseMocks(Optional.of(invalidPayload), Map.of());
 
-                final var actualResponse = function.fillXfaData(responseMocks.request(), responseMocks.context());
+        final var actualResponse = function.fillXfaData(responseMocks.request(), responseMocks.context());
 
-                assertSame(responseMocks.response(), actualResponse);
-                verify(responseMocks.request()).createResponseBuilder(HttpStatus.BAD_REQUEST);
-                verify(responseMocks.builder()).body("Request field 'validateOnly' must be a boolean.");
-        }
+        assertSame(responseMocks.response(), actualResponse);
+        verify(responseMocks.request()).createResponseBuilder(HttpStatus.BAD_REQUEST);
+        verify(responseMocks.builder()).body("Request field 'validateOnly' must be a boolean.");
+    }
 
     @Test
     void fillXfaDataReturnsConflictWhenPatchModeFailOnConflictAndValueDiffers() throws Exception {
@@ -349,12 +351,12 @@ class HttpTriggerFunctionsTest {
         throw new IllegalStateException("Could not locate sample file A4187.pdf for tests.");
     }
 
-    private static ResponseMocks setupResponseMocks(
-            final Optional<String> body,
+    private static <T> ResponseMocks<T> setupResponseMocks(
+            final Optional<T> body,
             final Map<String, String> queryParameters) {
 
         @SuppressWarnings("unchecked")
-        final var request = (HttpRequestMessage<Optional<String>>) mock(HttpRequestMessage.class);
+        final var request = (HttpRequestMessage<Optional<T>>) mock(HttpRequestMessage.class);
         final var context = mock(ExecutionContext.class);
         final var builder = mock(HttpResponseMessage.Builder.class);
         final var response = mock(HttpResponseMessage.class);
@@ -372,11 +374,11 @@ class HttpTriggerFunctionsTest {
         when(builder.status(any(HttpStatusType.class))).thenReturn(builder);
         when(builder.build()).thenReturn(response);
 
-        return new ResponseMocks(request, context, builder, response);
+        return new ResponseMocks<>(request, context, builder, response);
     }
 
-    private record ResponseMocks(
-            HttpRequestMessage<Optional<String>> request,
+    private record ResponseMocks<T>(
+            HttpRequestMessage<Optional<T>> request,
             ExecutionContext context,
             HttpResponseMessage.Builder builder,
             HttpResponseMessage response) {


### PR DESCRIPTION
This pull request updates the PDF form filler API and implementation to use raw binary PDF content instead of Base64-encoded strings, streamlining integration with Power Automate and SharePoint/OneDrive. It also improves error handling, updates the OpenAPI/Swagger definitions, and refines the test suite to match the new interface.

**API and OpenAPI/Swagger definition updates:**

* Changed all endpoints in `PdfFormFiller.swagger.json` to accept and return raw binary PDF data (`application/octet-stream` or `application/pdf`) instead of Base64-encoded strings, making integration with Power Automate file actions seamless. [[1]](diffhunk://#diff-cb108a7992c0fc3ff1eaf16c0a82a9102eafef6175daaf67e5c9d177b800e044L5-R44) [[2]](diffhunk://#diff-cb108a7992c0fc3ff1eaf16c0a82a9102eafef6175daaf67e5c9d177b800e044L62-R73) [[3]](diffhunk://#diff-cb108a7992c0fc3ff1eaf16c0a82a9102eafef6175daaf67e5c9d177b800e044L79-R98) [[4]](diffhunk://#diff-cb108a7992c0fc3ff1eaf16c0a82a9102eafef6175daaf67e5c9d177b800e044L100-R164) [[5]](diffhunk://#diff-cb108a7992c0fc3ff1eaf16c0a82a9102eafef6175daaf67e5c9d177b800e044L136-R208)
* Improved parameter descriptions, clarified authentication headers, and enhanced error response documentation for all endpoints. [[1]](diffhunk://#diff-cb108a7992c0fc3ff1eaf16c0a82a9102eafef6175daaf67e5c9d177b800e044L62-R73) [[2]](diffhunk://#diff-cb108a7992c0fc3ff1eaf16c0a82a9102eafef6175daaf67e5c9d177b800e044L79-R98) [[3]](diffhunk://#diff-cb108a7992c0fc3ff1eaf16c0a82a9102eafef6175daaf67e5c9d177b800e044L100-R164) [[4]](diffhunk://#diff-cb108a7992c0fc3ff1eaf16c0a82a9102eafef6175daaf67e5c9d177b800e044L136-R208)

**Java implementation changes:**

* Updated `HttpTriggerFunctions.java` to accept `byte[]` request bodies for PDF input, removing all Base64 decoding logic, and to return filled PDFs as raw binary with the correct `Content-Type`. [[1]](diffhunk://#diff-65fbd28909749b50078387a5bdba3437b9941e9dd7ca7bb9b620b968e3093a44L47-R56) [[2]](diffhunk://#diff-65fbd28909749b50078387a5bdba3437b9941e9dd7ca7bb9b620b968e3093a44L61-L62) [[3]](diffhunk://#diff-65fbd28909749b50078387a5bdba3437b9941e9dd7ca7bb9b620b968e3093a44L79-R89) [[4]](diffhunk://#diff-65fbd28909749b50078387a5bdba3437b9941e9dd7ca7bb9b620b968e3093a44L122-R133)
* Enhanced error handling to return HTTP 400 with a clear message for invalid or corrupted PDF files (including IOExceptions during PDF parsing).

**Test suite updates:**

* Updated tests to use `byte[]` for request bodies instead of Base64 strings, and adjusted test mocks and helper methods accordingly. [[1]](diffhunk://#diff-4ea7aec61256a2874006102fd28582cef0bdd8511020254e3488ebb6c899bc63R10) [[2]](diffhunk://#diff-4ea7aec61256a2874006102fd28582cef0bdd8511020254e3488ebb6c899bc63L29-R30) [[3]](diffhunk://#diff-4ea7aec61256a2874006102fd28582cef0bdd8511020254e3488ebb6c899bc63L41-R42) [[4]](diffhunk://#diff-4ea7aec61256a2874006102fd28582cef0bdd8511020254e3488ebb6c899bc63L53-R54) [[5]](diffhunk://#diff-4ea7aec61256a2874006102fd28582cef0bdd8511020254e3488ebb6c899bc63L65-R66) [[6]](diffhunk://#diff-4ea7aec61256a2874006102fd28582cef0bdd8511020254e3488ebb6c899bc63L75-R85) [[7]](diffhunk://#diff-4ea7aec61256a2874006102fd28582cef0bdd8511020254e3488ebb6c899bc63L352-R359) [[8]](diffhunk://#diff-4ea7aec61256a2874006102fd28582cef0bdd8511020254e3488ebb6c899bc63L375-R381)

These changes modernize the API, reduce friction for Power Platform users, and improve reliability and diagnostics.