### PR TITLE
fix function bug and add diagnostics

### DIFF
--- a/infrastructure/bicep/main.bicep
+++ b/infrastructure/bicep/main.bicep
@@ -126,6 +126,21 @@ module roleAssignments 'modules/roleAssignments.bicep' = {
   }
 }
 
+// Route all platform logs + metrics from the RG's resources into the workspace.
+module diagnostics 'modules/diagnostics.bicep' = {
+  name: 'diagnostics'
+  params: {
+    workspaceId: monitoring.outputs.workspaceId
+    storageAccountName: storageAccountName
+    functionAppName: functionAppName
+    slotName: slotName
+  }
+  dependsOn: [
+    storage
+    functionApp
+  ]
+}
+
 // Outputs consumed by scripts/configure-repo.ps1.
 output functionAppName string = functionApp.outputs.functionAppName
 output functionAppHostName string = functionApp.outputs.defaultHostName

--- a/infrastructure/bicep/modules/diagnostics.bicep
+++ b/infrastructure/bicep/modules/diagnostics.bicep
@@ -1,0 +1,208 @@
+// ---------------------------------------------------------------------------
+// diagnostics.bicep — Routes platform logs + metrics from every RG resource
+// that supports Azure Monitor diagnostic settings into the Log Analytics
+// workspace (PdfFormFillerLogs).
+//
+// Policy (for now): send EVERYTHING — `allLogs` category group + all metrics.
+// This is intentionally broad so we can see what's useful; trim categories
+// later once the signal is understood (watch the workspace daily-cap in
+// monitoring.bicep — currently 1 GB).
+//
+// Resources covered:
+//   - Function App (production site) + deployment slot  -> allLogs + AllMetrics
+//   - Storage blob/file/queue/table services            -> allLogs + Transaction
+//   - Storage account (root)                            -> Transaction + Capacity metrics
+//
+// Resources intentionally NOT covered (no diagnosticSettings support):
+//   - App Service plan (Microsoft.Web/serverfarms)
+//   - Application Insights component (it IS a telemetry sink)
+//   - User-assigned / system-assigned managed identities
+//   - Role assignments
+// The Log Analytics workspace itself can emit audit logs, but self-routing is
+// omitted here to avoid a recursive ingestion loop.
+// ---------------------------------------------------------------------------
+
+@description('Resource ID of the Log Analytics workspace that receives everything.')
+param workspaceId string
+
+@description('Storage account name whose services get access logs routed.')
+param storageAccountName string
+
+@description('Function App (production site) name.')
+param functionAppName string
+
+@description('Deployment slot name.')
+param slotName string
+
+var diagName = 'to-law'
+
+// ---- Existing resources (created by the other modules) --------------------
+
+resource functionApp 'Microsoft.Web/sites@2023-12-01' existing = {
+  name: functionAppName
+
+  resource slot 'slots' existing = {
+    name: slotName
+  }
+}
+
+resource storage 'Microsoft.Storage/storageAccounts@2023-05-01' existing = {
+  name: storageAccountName
+
+  resource blobService 'blobServices' existing = {
+    name: 'default'
+  }
+  resource fileService 'fileServices' existing = {
+    name: 'default'
+  }
+  resource queueService 'queueServices' existing = {
+    name: 'default'
+  }
+  resource tableService 'tableServices' existing = {
+    name: 'default'
+  }
+}
+
+// ---- Function App: production site + slot ---------------------------------
+
+resource siteDiagnostics 'Microsoft.Insights/diagnosticSettings@2021-05-01-preview' = {
+  name: diagName
+  scope: functionApp
+  properties: {
+    workspaceId: workspaceId
+    logs: [
+      {
+        categoryGroup: 'allLogs'
+        enabled: true
+      }
+    ]
+    metrics: [
+      {
+        category: 'AllMetrics'
+        enabled: true
+      }
+    ]
+  }
+}
+
+resource slotDiagnostics 'Microsoft.Insights/diagnosticSettings@2021-05-01-preview' = {
+  name: diagName
+  scope: functionApp::slot
+  properties: {
+    workspaceId: workspaceId
+    logs: [
+      {
+        categoryGroup: 'allLogs'
+        enabled: true
+      }
+    ]
+    metrics: [
+      {
+        category: 'AllMetrics'
+        enabled: true
+      }
+    ]
+  }
+}
+
+// ---- Storage account root (metrics only; no logs at account scope) ---------
+
+resource storageDiagnostics 'Microsoft.Insights/diagnosticSettings@2021-05-01-preview' = {
+  name: diagName
+  scope: storage
+  properties: {
+    workspaceId: workspaceId
+    metrics: [
+      {
+        category: 'Transaction'
+        enabled: true
+      }
+      {
+        category: 'Capacity'
+        enabled: true
+      }
+    ]
+  }
+}
+
+// ---- Storage services: blob / file / queue / table (access logs) ----------
+
+resource blobDiagnostics 'Microsoft.Insights/diagnosticSettings@2021-05-01-preview' = {
+  name: diagName
+  scope: storage::blobService
+  properties: {
+    workspaceId: workspaceId
+    logs: [
+      {
+        categoryGroup: 'allLogs'
+        enabled: true
+      }
+    ]
+    metrics: [
+      {
+        category: 'Transaction'
+        enabled: true
+      }
+    ]
+  }
+}
+
+resource fileDiagnostics 'Microsoft.Insights/diagnosticSettings@2021-05-01-preview' = {
+  name: diagName
+  scope: storage::fileService
+  properties: {
+    workspaceId: workspaceId
+    logs: [
+      {
+        categoryGroup: 'allLogs'
+        enabled: true
+      }
+    ]
+    metrics: [
+      {
+        category: 'Transaction'
+        enabled: true
+      }
+    ]
+  }
+}
+
+resource queueDiagnostics 'Microsoft.Insights/diagnosticSettings@2021-05-01-preview' = {
+  name: diagName
+  scope: storage::queueService
+  properties: {
+    workspaceId: workspaceId
+    logs: [
+      {
+        categoryGroup: 'allLogs'
+        enabled: true
+      }
+    ]
+    metrics: [
+      {
+        category: 'Transaction'
+        enabled: true
+      }
+    ]
+  }
+}
+
+resource tableDiagnostics 'Microsoft.Insights/diagnosticSettings@2021-05-01-preview' = {
+  name: diagName
+  scope: storage::tableService
+  properties: {
+    workspaceId: workspaceId
+    logs: [
+      {
+        categoryGroup: 'allLogs'
+        enabled: true
+      }
+    ]
+    metrics: [
+      {
+        category: 'Transaction'
+        enabled: true
+      }
+    ]
+  }
+}

--- a/infrastructure/bicep/modules/functionApp.bicep
+++ b/infrastructure/bicep/modules/functionApp.bicep
@@ -10,7 +10,15 @@
 //   clientId / clientSecret / tenantId / WebUrl (stale OBO/Graph leftovers)
 //   JAVA_OPTS / HTTP_PLATFORM_DEBUG_PORT  (remote-debug artifacts on the slot)
 //   WEBSITE_HTTPLOGGING_RETENTION_DAYS    (slot-only drift)
-//   WEBSITE_RUN_FROM_PACKAGE              (deployment-managed; re-added by deploy)
+//
+// WEBSITE_RUN_FROM_PACKAGE is set to '1' here (NOT dropped). The GitHub Actions
+// deploy (Azure/functions-action, Run-From-Package) uploads the app package to
+// d:\home\data\SitePackages and writes packagename.txt; '1' makes the host run
+// the latest such package. This MUST be declared here because app settings are
+// applied as a full array — omitting it would STRIP the setting on every infra
+// deploy, causing the host to fall back to the stale content-share wwwroot
+// (old code) until the next code deploy. Keeping it '1' is idempotent with the
+// deploy action, which also sets '1'.
 //
 // Storage auth: AzureWebJobsStorage uses identity-based (keyless) connection via
 // the site/slot SAMI. The content share (WEBSITE_CONTENT*) still needs a
@@ -100,6 +108,13 @@ var sharedAppSettings = [
   {
     name: 'WEBSITE_CONTENTAZUREFILECONNECTIONSTRING'
     value: contentShareConnectionString
+  }
+  // Run-From-Package: the GitHub Actions deploy uploads the package to
+  // SitePackages and sets this to '1'. Declared here so infra deploys PRESERVE
+  // it instead of stripping it (see module header for the full rationale).
+  {
+    name: 'WEBSITE_RUN_FROM_PACKAGE'
+    value: '1'
   }
 ]
 


### PR DESCRIPTION
This pull request introduces comprehensive logging and diagnostics for all supported resources in the resource group, and clarifies the handling of the `WEBSITE_RUN_FROM_PACKAGE` app setting to ensure reliable deployments. The main changes are the addition of a new diagnostics Bicep module that configures diagnostic settings for the Function App and Storage Account, and a fix to preserve the `WEBSITE_RUN_FROM_PACKAGE` setting during infrastructure deployments.

**Diagnostics and Monitoring Enhancements:**

* Added a new `diagnostics.bicep` module that configures platform logs and metrics routing for all supported resources (Function App, deployment slot, storage services) to the Log Analytics workspace, ensuring all logs and metrics are captured for analysis.
* Integrated the new `diagnostics` module into `main.bicep`, wiring up the required parameters and dependencies so that diagnostics are set up automatically for new deployments.

**Function App Deployment Reliability:**

* Updated the documentation and implementation in `functionApp.bicep` to ensure the `WEBSITE_RUN_FROM_PACKAGE` app setting is always set to `'1'`, preventing infrastructure deployments from accidentally removing it and causing the Function App to run outdated code. [[1]](diffhunk://#diff-3e6a22e02fd4c385c5264037041259558346c01a1906d8c86dedbcfa3cc98867L13-R21) [[2]](diffhunk://#diff-3e6a22e02fd4c385c5264037041259558346c01a1906d8c86dedbcfa3cc98867R112-R118)

These changes improve observability of the platform and ensure reliable, idempotent deployments for the Function App.